### PR TITLE
Make DBusError internal and a noncopyable struct

### DIFF
--- a/Sources/DBusSwift/DBusConnection.swift
+++ b/Sources/DBusSwift/DBusConnection.swift
@@ -144,9 +144,7 @@ public final class DBusConnection: @unchecked Sendable {
         var cError = CDBus.DBusError()
         dbus_error_init(&cError)
         
-        rule.withCString { cRule in
-            dbus_bus_add_match(connection, cRule, &cError)
-        }
+        dbus_bus_add_match(connection, rule, &cError)
         
         if dbus_error_is_set(&cError) != 0 {
             let errorMessage = String(cString: cError.message)
@@ -166,9 +164,7 @@ public final class DBusConnection: @unchecked Sendable {
         var cError = CDBus.DBusError()
         dbus_error_init(&cError)
         
-        rule.withCString { cRule in
-            dbus_bus_remove_match(connection, cRule, &cError)
-        }
+        dbus_bus_remove_match(connection, rule, &cError)
         
         if dbus_error_is_set(&cError) != 0 {
             let errorMessage = String(cString: cError.message)
@@ -190,9 +186,7 @@ public final class DBusConnection: @unchecked Sendable {
         var cError = CDBus.DBusError()
         dbus_error_init(&cError)
         
-        let result = name.withCString { cName in
-            dbus_bus_request_name(connection, cName, flags, &cError)
-        }
+        let result = dbus_bus_request_name(connection, name, flags, &cError)
         
         if dbus_error_is_set(&cError) != 0 {
             let errorMessage = String(cString: cError.message)

--- a/Sources/DBusSwift/DBusTypes.swift
+++ b/Sources/DBusSwift/DBusTypes.swift
@@ -76,7 +76,7 @@ extension Int32 {
 ///
 /// This class provides a Swift-friendly interface for handling D-Bus errors.
 /// It wraps the C DBusError structure and provides methods for checking, setting, and clearing errors.
-public final class DBusError {
+internal struct DBusError: ~Copyable {
     /// The error name, typically in reverse-DNS format (e.g., "org.freedesktop.DBus.Error.ServiceUnknown").
     private var _name: String?
     
@@ -84,12 +84,12 @@ public final class DBusError {
     private var _message: String?
     
     /// The underlying C DBusError structure.
-    internal var _error: CDBus.DBusError
+    private let _error: UnsafeMutablePointer<CDBus.DBusError>
     
     /// Initializes a new D-Bus error.
     public init() {
-        _error = CDBus.DBusError()
-        dbus_error_init(&_error)
+        _error = UnsafeMutablePointer<CDBus.DBusError>.allocate(capacity: 1)
+        dbus_error_init(_error)
     }
     
     /// Initializes a new D-Bus error with the given name and message.
@@ -98,34 +98,34 @@ public final class DBusError {
     ///   - name: The error name, typically in reverse-DNS format.
     ///   - message: The human-readable error message.
     internal init(name: String, message: String) {
-        _error = CDBus.DBusError()
-        dbus_error_init(&_error)
+        _error = UnsafeMutablePointer<CDBus.DBusError>.allocate(capacity: 1)
+        dbus_error_init(_error)
         _name = name
         _message = message
         
         name.withCString { cName in
             message.withCString { cMessage in
-                dbus_set_error_const(&_error, cName, cMessage)
+                dbus_set_error_const(_error, cName, cMessage)
             }
         }
     }
     
     deinit {
-        dbus_error_free(&_error)
+        dbus_error_free(_error)
     }
     
     /// The error name, typically in reverse-DNS format (e.g., "org.freedesktop.DBus.Error.ServiceUnknown").
     public var name: String? {
-        if dbus_error_is_set(&_error) != 0 {
-            return String(cString: _error.name)
+        if dbus_error_is_set(_error) != 0 {
+            return String(cString: _error.pointee.name)
         }
         return _name
     }
     
     /// The human-readable error message.
     public var message: String? {
-        if dbus_error_is_set(&_error) != 0 {
-            return String(cString: _error.message)
+        if dbus_error_is_set(_error) != 0 {
+            return String(cString: _error.pointee.message)
         }
         return _message
     }
@@ -134,7 +134,7 @@ public final class DBusError {
     ///
     /// - Returns: `true` if an error is set, `false` otherwise.
     public var isSet: Bool {
-        return dbus_error_is_set(&_error) != 0
+        return dbus_error_is_set(_error) != 0
     }
     
     /// Clears the error state.
@@ -160,9 +160,9 @@ public final class DBusError {
     ///     print("Error occurred: \(error.name ?? "") - \(error.message ?? "")")
     /// }
     /// ```
-    public func clear() {
-        dbus_error_free(&_error)
-        dbus_error_init(&_error)
+    public mutating func clear() {
+        dbus_error_free(_error)
+        dbus_error_init(_error)
         _name = nil
         _message = nil
     }
@@ -178,15 +178,11 @@ public final class DBusError {
     /// - Parameters:
     ///   - name: The error name, typically in reverse-DNS format.
     ///   - message: The human-readable error message.
-    internal func setError(name: String, message: String) {
+    internal mutating func setError(name: String, message: String) {
         _name = name
         _message = message
         
-        name.withCString { cName in
-            message.withCString { cMessage in
-                dbus_set_error_const(&_error, cName, cMessage)
-            }
-        }
+        dbus_set_error_const(_error, name, message)
     }
     
     /// Gets the underlying C DBusError structure.
@@ -214,7 +210,7 @@ public final class DBusError {
     /// ```
     ///
     /// - Returns: A pointer to the underlying C DBusError structure.
-    internal func getError() -> UnsafeMutablePointer<CDBus.DBusError> {
-        withUnsafeMutablePointer(to: &_error) { $0 }
+    internal func withError<T, E: Error>(_ perform: (inout CDBus.DBusError) throws(E) -> T) throws(E) -> T {
+        try perform(&_error.pointee)
     }
 }

--- a/Tests/DBusSwiftTests/DBusErrorTests.swift
+++ b/Tests/DBusSwiftTests/DBusErrorTests.swift
@@ -8,46 +8,59 @@ struct DBusErrorTests {
     /// Tests the basic functionality of the DBusError class.
     @Test("DBusError Basics")
     func testDBusErrorBasics() throws {
-        let error = DBusError()
+        var error = DBusError()
         
+        var isSet = error.isSet
+        var name = error.name
+        var message = error.message
         // Initially, the error should not be set
-        #expect(!error.isSet)
-        #expect(error.name == nil)
-        #expect(error.message == nil)
+        #expect(!isSet)
+        #expect(name == nil)
+        #expect(message == nil)
         
         // Set the error using internal method
         error.setError(name: "org.example.Error.Test", message: "Test error message")
         
         // Check that the error is now set
-        #expect(error.isSet)
-        #expect(error.name == "org.example.Error.Test")
-        #expect(error.message == "Test error message")
+        isSet = error.isSet
+        name = error.name
+        message = error.message
+        #expect(isSet)
+        #expect(name == "org.example.Error.Test")
+        #expect(message == "Test error message")
         
         // Clear the error
         error.clear()
         
         // Check that the error is cleared
-        #expect(!error.isSet)
-        #expect(error.name == nil)
-        #expect(error.message == nil)
+        isSet = error.isSet
+        name = error.name
+        message = error.message
+        #expect(!isSet)
+        #expect(name == nil)
+        #expect(message == nil)
     }
     
     /// Tests the clear method of the DBusError class.
     @Test("DBusError Clear")
     func testDBusErrorClear() throws {
-        let error = DBusError()
+        var error = DBusError()
         
         // Set the error
         error.setError(name: "org.example.Error.Test", message: "Test error message")
-        #expect(error.isSet)
+        var isSet = error.isSet
+        #expect(isSet)
         
         // Clear the error
         error.clear()
         
         // Check that the error is cleared
-        #expect(!error.isSet)
-        #expect(error.name == nil)
-        #expect(error.message == nil)
+        isSet = error.isSet
+        let name = error.name
+        let message = error.message
+        #expect(!isSet)
+        #expect(name == nil)
+        #expect(message == nil)
     }
     #endif
 }

--- a/Tests/DBusSwiftTests/DBusSwiftTests.swift
+++ b/Tests/DBusSwiftTests/DBusSwiftTests.swift
@@ -126,8 +126,7 @@ struct DBusSwiftTests {
     func testSystemBusConnection() async {
         do {
             let dbus = try DBusAsync(busType: .system)
-            let connection = await dbus.getConnection()
-            #expect(connection != nil)
+            let _ = await dbus.getConnection()
         } catch {
             // Allow failure if D-Bus isn't running
             print("Warning: Could not connect to system bus: \(error)")
@@ -158,8 +157,7 @@ struct DBusSwiftTests {
     func testDBusAsync() async {
         do {
             let dbus = try DBusAsync(busType: .session)
-            let connection = await dbus.getConnection()
-            #expect(connection != nil)
+            let _ = await dbus.getConnection()
         } catch {
             print("Warning: Could not create DBusAsync: \(error)")
         }


### PR DESCRIPTION
It wasn't used in public API, so I made it internal. And to avoid ARC calls, I made it noncopyable. We can _very_ easily revert to a class, and the compiler can optimise almost every ARC call we would make anyways. But we can't guarantee Sendability for this error right now anyways, so I feel that a noncopyable struct is more valid.